### PR TITLE
Use different cron schedules on clients running refresh-mcollective-metadata

### DIFF
--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -6,8 +6,7 @@ class mcollective::server::config::factsource::yaml {
 
   $excluded_facts      = $mcollective::excluded_facts
   $yaml_fact_path_real = $mcollective::yaml_fact_path_real
-  $cron_minute_value   = generate('/usr/bin/env','sh','-c',
-     'printf $((RANDOM%60+0))')
+  $cron_minute_value   = rand_fqdn(60, $::uniqueid)
 
   # Template uses:
   #   - $yaml_fact_path_real

--- a/manifests/server/config/factsource/yaml.pp
+++ b/manifests/server/config/factsource/yaml.pp
@@ -6,6 +6,8 @@ class mcollective::server::config::factsource::yaml {
 
   $excluded_facts      = $mcollective::excluded_facts
   $yaml_fact_path_real = $mcollective::yaml_fact_path_real
+  $cron_minute_value   = generate('/usr/bin/env','sh','-c',
+     'printf $((RANDOM%60+0))')
 
   # Template uses:
   #   - $yaml_fact_path_real
@@ -20,7 +22,8 @@ class mcollective::server::config::factsource::yaml {
     environment => "PATH=/opt/puppet/bin:${::path}",
     command     => "${mcollective::core_libdir}/refresh-mcollective-metadata",
     user        => 'root',
-    minute      => [ '0', '15', '30', '45' ],
+    minute      => $cron_minute_value,
+    hour        => '0-23/2',
   }
   exec { 'create-mcollective-metadata':
     path    => "/opt/puppet/bin:${::path}",


### PR DESCRIPTION
refresh-mcollective-metadata is being run at fixed moments within an hour, being at 0, 15, 30, and the 45th minute. When managing a lot of virtual hosts (300-600+)  via puppet, they all demand simultaneously that the hypervisor will provide them with CPU resources, which can result in a denial of service-like effect due to increased I/O waits on the virtual hosts, and enormous ready-times on the hypervisors. Therefore, cron jobs should be spread over various moments in time.